### PR TITLE
Implement Mock class returned from the mock method

### DIFF
--- a/sandbox/index.ts
+++ b/sandbox/index.ts
@@ -11,9 +11,9 @@ const headers = new Headers({ "x-foo-bar": "baz" });
 const data = { foo: "bar" };
 
 // Mock fetch
-
+let mockInstance;
 if (MOCK_FETCH)
-    mock(url, { method, headers, data });
+    mockInstance = mock(url, { method, headers, data });
 
 // Call fetch method
 
@@ -22,3 +22,16 @@ console.log("Response =>", response);
 
 const body = await response.json();
 console.log("Body =>", body);
+
+if(mockInstance) {
+    console.log("Mock Called =>", mockInstance.called);
+
+    mockInstance.clear();
+
+    // Fetch again to confirm the mock was cleared.
+    const response = await fetch(url, { method, headers });
+    console.log("Cleared Response =>", response);
+
+    const body = await response.json();
+    console.log("Cleared Body =>", body);
+}

--- a/src/mockClass.ts
+++ b/src/mockClass.ts
@@ -1,0 +1,36 @@
+import { MockOptions } from "./types";
+import { MOCKED_REQUESTS } from "./mock";
+
+/**
+ * A class that represents a mocked request.
+ * @param key - The key of the mocked request, an instance of RegExp.
+ * @param options - The options for the mocked request.
+ */
+export class Mock {
+    public calledTimes: number = 0;
+
+    constructor(public key: RegExp, public options: MockOptions) {
+    }
+
+    /**
+     * Clear the mocked request.
+     */
+    public clear() {
+        MOCKED_REQUESTS.delete(this.key);
+    }
+
+    /**
+     * Check if the mocked request has been called.
+     */
+    public get called() {
+        return !!this.calledTimes;
+    }
+
+    /**
+     * Increment the number of times the mocked request has been called.
+     * It's used internally. Call only, if you know what you're doing.
+     */
+    public _incrementCalled() {
+        this.calledTimes++;
+    }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { Mock } from "./mockClass";
 import { DEFAULT_MOCK_OPTIONS, STATUS_TEXT_MAP } from "./constants";
 import { MockOptions } from "./types";
 
@@ -22,9 +23,11 @@ export function wildcardToRegex(wildcardString: string): RegExp {
 /**
  * @description Find a requests.
  */
-export const findRequest = (original: [string, RequestInit?]) => (mocked: [RegExp, MockOptions?]) => {
+export const findRequest = (original: [string, RequestInit?]) => (mocked: [RegExp, Mock?]) => {
     const [keyA, optionsA] = original;
-    const [keyB, optionsB] = mocked;
+    const [keyB, mockB] = mocked;
+
+    const optionsB = mockB?.options;
 
     // Match keys.
     const keysMatch = keyA.toString() === keyB.toString() || keyA.match(keyB);

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -28,7 +28,8 @@ describe("Mock", () => {
                 name: "John Doe",
             },
         };
-        expect(mock(request, options)).toBe(undefined);
+
+        expect(mock(request, options)?.called).toBe(true);
         await fetch(`${API_URL}/users`);
     });
 
@@ -144,6 +145,27 @@ describe("Mock", () => {
             await fetch(`${API_URL}/posts`);
         }
          expect(act).toThrow();
+    });
+
+    test("mock: should clear a single mock", async () => {
+        const request = `${API_URL}/users`;
+        const options = {
+            data: {
+                id: 1,
+                name: "John Doe",
+            },
+        };
+        const mockInstance = mock(request, options);
+        const response = await fetch(`${API_URL}/users`);
+        const data = await response.json();
+        expect(data).toEqual(options.data);
+
+        mockInstance.clear();
+
+        const act = async () => {
+            await fetch(`${API_URL}/users`);
+        }
+        expect(act).toThrow();
     });
 
     test("mock: should restore the original fetch method after the test", () => {


### PR DESCRIPTION
This PR will implement a Mock class that is returned from the mock method. It exposes several methods for cleaning the single mock, indication whether the mock was called and more.

### Examples

```
const mockInstance = mock(url, options);

// ... call fetch to run the mock

console.log(mockInstance.called); // => true

mockInstance.clear();

// ... call fetch again to see the mock not being executed anymore.
```