### PR TITLE
🐛 fix(#2): clearMocks should not prevent all upcoming mocks

### DIFF
--- a/src/mock.ts
+++ b/src/mock.ts
@@ -53,6 +53,8 @@ export const clearMocks = () => {
     MOCKED_REQUESTS.clear();
     // @ts-ignore
     globalThis.fetch = ORIGINAL_FETCH;
+    // @ts-ignore
+    ORIGINAL_FETCH = undefined;
 }
 
 /**

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, describe } from "bun:test";
-import { mock, clearMocks } from "../src/mock";
+import { describe, expect, test } from "bun:test";
+import { clearMocks, mock } from "../src/mock";
 
 const API_URL = `https://bun-bagel.sweet/api/v1`;
 
@@ -144,6 +144,14 @@ describe("Mock", () => {
             await fetch(`${API_URL}/posts`);
         }
          expect(act).toThrow();
+    });
+
+    test("mock: should restore the original fetch method after the test", () => {
+      mock(`${API_URL}/cats`, { data: { meow: "meow" } });
+      const mockedFetch = globalThis.fetch;
+      clearMocks();
+      mock(`${API_URL}/cats`, { data: { purr: "purr" } });
+      expect(globalThis.fetch).toBe(mockedFetch);
     });
 
     test("mock: should restore the original fetch method after the test", () => {


### PR DESCRIPTION
fix for #2 