### PR TITLE
Added option to mock error during fetch

### DIFF
--- a/src/mock.ts
+++ b/src/mock.ts
@@ -80,6 +80,8 @@ const MOCKED_FETCH = async (_request: Request | RegExp | string, init?: RequestI
     if(process.env.VERBOSE)
         console.debug("\x1b[2mMocked fetch called\x1b[0m", _path);
 
+    if (mockedRequest[1].throw) throw mockedRequest[1].throw;
+    
     const mockedStatus = mockedRequest[1].response?.status || 200;
 
     return makeResponse(mockedStatus, _path, mockedRequest[1]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type MockOptions = {
     headers?: RequestInit['headers'];
     method?: RequestInit['method'];
     response?: MockResponse;
+    throw?: Error;
 };
 
 /**

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -192,6 +192,20 @@ describe("Mock", () => {
         expect(response.headers).toEqual({ "x-baz-qux": "quux" });
     });
 
+    test("mock: should mock a request that throws a fetch error", async () => {
+        const request = new Request(`${API_URL}/cats`);
+        const options: MockOptions = {
+            throw: new Error("Mocked error"),
+        };
+        mock(request, options);
+        try {
+            await fetch(`${API_URL}/cats`);
+            expect().fail();
+        } catch (e) {
+            expect(e.message).toEqual("Mocked error");
+        }
+    });
+
     test("mock: should not mock a request if it is not registered", async () => {
         const act = async () => {
             await fetch(`${API_URL}/posts`);


### PR DESCRIPTION
Since `fetch` can throw errors on various conditions, I would expect this mock to give developers the ability to mock fetch error throws.

I implemented this feature by extending `MockOptions` with an optional `throw` property of type `Error`.
I also added a test to make sure that the mocked `fetch` call with throw an exception if the `throw` property is set.