### PR TITLE
:bug: Fixed typescript configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "bun run src/index.ts",
     "build": "bun run build:bun && bun run build:emitDeclarations",
     "build:bun": "bun build ./src/index.ts --outdir dist --target bun --minify --sourcemap=external",
-    "build:emitDeclarations": "tsc --emitDeclarationOnly --project tsconfig.json --tsBuildInfoFile './dist/.tsbuildinfo'",
+    "build:emitDeclarations": "tsc --emitDeclarationOnly --project tsconfig.build.json --tsBuildInfoFile './dist/.tsbuildinfo'",
     "sandbox": "bun run ./sandbox/index.ts",
     "test": "bun test --coverage",
     "lint": "bunx biome lint --write ./src ./tests",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,7 +76,7 @@ export const makeResponse = (
 		status,
 		statusText: status,
 		url,
-		headers: response?.headers ?? headers,
+		headers: new Headers(response?.headers ?? headers),
 		text: () => Promise.resolve(body),
 		json: () => Promise.resolve(body),
 		redirected: false,

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -40,7 +40,10 @@ describe("Mock", () => {
 			},
 		};
 		expect(mock(request, options)).toBe(true);
-		expect(mock(request, options)).toBe(undefined);
+
+		// for some reason the expect function fails to infer the return type correctly
+		// and only infers it as boolean so we specify the return type explicitly as the return type of the function
+		expect<ReturnType<typeof mock>>(mock(request, options)).toBe(undefined);
 		await fetch(`${API_URL}/users`);
 	});
 
@@ -192,7 +195,8 @@ describe("Mock", () => {
 		const response = await fetch(`${API_URL}/users`, {
 			headers: { "x-foo-bar": "baz" },
 		});
-		expect(response.headers).toEqual({ "x-baz-qux": "quux" });
+
+		expect(response.headers).toEqual(new Headers({ "x-baz-qux": "quux" }));
 	});
 
 	test("mock: should not mock a request if it is not registered", async () => {

--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -41,8 +41,8 @@ describe("Mock", () => {
 		};
 		expect(mock(request, options)).toBe(true);
 
-		// for some reason the expect function fails to infer the return type correctly
-		// and only infers it as boolean so we specify the return type explicitly as the return type of the function
+		// for some reason the expect function fails to infer the return type correctly and only infers
+		// it as boolean so we specify the type of expect explicitly as the return type of the function
 		expect<ReturnType<typeof mock>>(mock(request, options)).toBe(undefined);
 		await fetch(`${API_URL}/users`);
 	});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"module": "esnext",
+		"target": "esnext",
+		"moduleResolution": "node",
+		"moduleDetection": "force",
+		"noEmit": false,
+		"declaration": true,
+		"composite": true,
+		"strict": true,
+		"downlevelIteration": true,
+		"skipLibCheck": true,
+		"jsx": "react-jsx",
+		"allowSyntheticDefaultImports": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowJs": true,
+		"types": [
+			"bun-types" // add Bun global
+		]
+	}
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-	"extends": "./tsconfigbase.json",
+	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfigbase.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist"
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "sandbox", "tests"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,8 @@
 {
-  "compilerOptions": {
-    "lib": ["ESNext"],
-    "module": "esnext",
-    "target": "esnext",
-    "moduleResolution": "node",
-    "moduleDetection": "force",
-    "outDir": "dist",
-    "rootDir": "src",
-    "noEmit": false,
-    "declaration": true,
-    "composite": true,
-    "strict": true,
-    "downlevelIteration": true,
-    "skipLibCheck": true,
-    "jsx": "react-jsx",
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
-    "allowJs": true,
-    "types": [
-      "bun-types" // add Bun global
-    ]
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "tests", "sandbox"]
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"rootDirs": ["src", "tests"]
+	},
+	"include": ["src/**/*.ts", "tests/**/*.ts"],
+	"exclude": ["node_modules", "dist", "sandbox"]
 }


### PR DESCRIPTION
- Created a separated tsconfig file for the build step that includes only the `src` folder for emitted type declarations
- Fixed type issues in `tests/mock.test.ts`
- Adapted the headers of the mocked response to Web standards by returning an instance of Headers instead of an object (which caused a misleading type error in `tests/mock.test.ts`)