### PR TITLE
fix: support more BodyInit when creating Response

### DIFF
--- a/tests/mock.test.ts
+++ b/tests/mock.test.ts
@@ -192,7 +192,9 @@ describe("Mock", () => {
         };
         mock(request, options);
         const response = await fetch(`${API_URL}/users`, { headers: new Headers({ "x-foo-bar": "baz"  }) });
-        expect([...response.headers.entries()]).toEqual([[ "x-baz-qux", "quux" ]]);
+        expect([...response.headers.entries()]).toHaveLength(2);
+        expect(response.headers.get("content-type")).toContain("application/json");
+        expect(response.headers.get("x-baz-qux")).toEqual("quux");
     });
 
     test("mock: should mock a request with Blob", async () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -89,6 +89,15 @@ describe("Utils", () => {
 			expect(await response.json()).toEqual({ foo: "bar" });
 		});
 
+		test("should return a Response object with Buffer", async () => {
+			const response = makeResponse(200, {
+				response: { data: Buffer.from("ABC", "utf-8") },
+			});
+
+			const buffer = Buffer.from(await response.arrayBuffer());
+			expect(buffer.toString("utf-8")).toEqual("ABC");
+		});
+
 		test("should return a Response object with headers", () => {
 			const response = makeResponse(200, {
 				response: { headers: new Headers({ "x-foo-bar": "baz" }) },


### PR DESCRIPTION
# Current situation:

```ts
test("should return a Response object with Buffer", async () => {
	const response = makeResponse(200, {
		response: { data: Buffer.from("ABC", "utf-8") },
	});

	const buffer = Buffer.from(await response.arrayBuffer());
	expect(buffer.toString("utf-8")).toEqual("ABC");
});
```

This fails, because what we get is: `{"type":"Buffer","data":[65,66,67]}` (which is `JSON.stringify(buffer)`)

This fixes it by checking any type of valid BodyInit and only using JSON.stringify if it's not a valid one. So far it would only check for Blob